### PR TITLE
Add Tuning & Analysis section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A curated list of awesome drones, builds, kits, DIYs, resources and other relate
 Please feel free to [pull requests](https://github.com/piyushchauhan/awesome-drones/pulls)
 
 ## Table of Contents
-
 * [Builds and Hardware](#Builds-and-Hardware)
 * [First Person View-FPV](#First-Person-View-FPV)
 * [Unmanned Aerial Vehicle-UAV](#Unmanned-Aerial-Vehicle-UAV)
@@ -28,6 +27,8 @@ Please feel free to [pull requests](https://github.com/piyushchauhan/awesome-dro
 ### Simulator
 - [Mircosot AirSim](https://github.com/microsoft/AirSim)
 
+### Tuning & Analysis
+- [FPVtune](https://fpvtune.com) - Automatic Betaflight PID tuning from blackbox logs. Upload flight data, get optimized PID and filter settings in minutes.
 
 ## News
 - [sUAV News](https://www.suasnews.com/)


### PR DESCRIPTION
## What this PR does

Adds a new **Tuning & Analysis** subsection under the existing **Tools** section, with an entry for [FPVtune](https://fpvtune.com).

## Why

The Tools section currently only has a Simulator subsection. FPV drone PID tuning is a major part of the hobby, and there are tools specifically built for this purpose. FPVtune is a free, open-source web tool that reads Betaflight blackbox logs and generates optimized PID/filter settings automatically.

## Placement

Added under **Tools > Tuning & Analysis**, after the existing Simulator subsection. This keeps the Tools section organized by category.